### PR TITLE
{build/targets}.sh: Allow set CC compiler from environment

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -10,8 +10,8 @@
 # change these for your host systems
 
 system="linux" # only linux supported in this version
-linux_host=
-linux_prefix="/usr"
+linux_host=${CC}
+linux_prefix=
 linux_cross_host=
 linux_cross_prefix=
 
@@ -214,8 +214,8 @@ fi
 sys_flags=( ${flags[@]} )
 #echo ${sys_flags[@]}
 if [ -n "${!host}" ]; then
-    cc="${!host}-${cc}"
-    cpp="${!host}-${cpp}"
+    cc="${!host}"
+    cpp="${!host}"
 fi
 if [[ $system == "win32" ]]; then
     cc="${cc}.exe"

--- a/targets.sh
+++ b/targets.sh
@@ -14,12 +14,12 @@ if [[ $tls_lib == "openssl" ]]; then
     se_core_flags=( -DOPENSSL_TLS )
     command -v openssl > /dev/null
     if [ $? -eq 1 ]; then
-	echo "The openssl command is not found, make sure that OpenSSL version 1.1.0 installed."
+	echo "The openssl command is not found, make sure that OpenSSL version 1.1.* installed."
 	exit 0
     fi
     version=`openssl version -a`
-    if [[ ! ($version =~ "OpenSSL 1.1.0") ]]; then
-	echo "The EPRI 2030.5 client requires OpenSSL version 1.1.0."
+    if [[ ! ($version =~ "OpenSSL 1.1.") ]]; then
+	echo "The EPRI 2030.5 client requires OpenSSL version 1.1.*."
 	echo "openssl version -a"
 	echo $version
 	exit 0


### PR DESCRIPTION
This patch is based on catch-twenty-two [1] but dosen't enforce
to certain OpenSSL version because the Yocto/OE sumo version
provides OpenSSL 1.1.1 so let the build fail if another version
is used.

Adapted test of OpenSSL version to allow 1.1.* versions.

[1]
https://github.com/catch-twenty-two/ieee-2030.5-client/commit/c534af507e

Signed-off-by: catch-twenty-two <catch22@fastmail.net>
Signed-off-by: Aníbal Limón <limon.anibal@gmail.com>